### PR TITLE
Fix urls for scenario pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ for task_id, train_taskset in enumerate(scenario):
 
 |Name | Acronym | Supported | Scenario |
 |:----|:---|:---:|:---:|
-| **New Instances** | NI | :white_check_mark: | [Instances Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenario.html#)|
-| **New Classes** | NC | :white_check_mark: |[Classes Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenario.html#instance-incremental)|
-| **New Instances & Classes** | NIC | :white_check_mark: | [Data Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenario.html#)|
+| **New Instances** | NI | :white_check_mark: | [Instances Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenarios.html#instance-incremental)|
+| **New Classes** | NC | :white_check_mark: |[Classes Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenarios.html#classes-incremental)|
+| **New Instances & Classes** | NIC | :white_check_mark: | [Data Incremental](https://continuum.readthedocs.io/en/latest/_tutorials/scenarios/scenarios.html#new-class-and-instance-incremental)|
 
 ### Supported Datasets:
 


### PR DESCRIPTION
Some links inside the readme are broken.

This tiny PR fixes this.