### PR TITLE
Add test for ImageNet100.

### DIFF
--- a/continuum/datasets/base.py
+++ b/continuum/datasets/base.py
@@ -124,13 +124,13 @@ class ImageFolderDataset(_ContinuumDataset):
         self.data_folder = data_folder
         super().__init__(train=train, download=download)
 
-        self.dataset = torchdata.ImageFolder(data_folder)
 
     @property
     def data_type(self) -> str:
         return "image_path"
 
     def get_data(self) -> Tuple[np.ndarray, np.ndarray, Union[None, np.ndarray]]:
+        self.dataset = torchdata.ImageFolder(self.data_folder)
         return self._format(self.dataset.imgs)
 
     @staticmethod

--- a/tests/test_imagenet.py
+++ b/tests/test_imagenet.py
@@ -1,0 +1,63 @@
+import os
+
+import pytest
+
+from continuum.datasets import ImageNet100
+from continuum.scenarios import ClassIncremental
+
+
+nb_images_per_subset = {
+    True: 129395,  # train
+    False: 5000    # test
+}
+
+
+@pytest.fixture
+def ImageNet100Test(tmpdir):
+    folder = os.path.join(tmpdir, "imagenet100test")
+    os.makedirs(folder)
+    return ImageNet100(folder, data_subset=None, download=True, train=False)
+
+
+@pytest.fixture
+def ImageNet100Train(tmpdir):
+    folder = os.path.join(tmpdir, "imagenet100train")
+    os.makedirs(folder)
+    return ImageNet100(folder, data_subset=None, download=True, train=True)
+
+
+@pytest.mark.parametrize("train", [True, False])
+def test_parsing_imagenet100(ImageNet100Train, ImageNet100Test, train):
+    dataset = ImageNet100Train if train else ImageNet100Test
+    x, y, t = dataset.get_data()
+
+    assert all("train" if train else "test" in path for path in x)
+
+
+
+@pytest.mark.parametrize("train", [True, False])
+def test_nb_imagenet100(ImageNet100Train, ImageNet100Test, train):
+    dataset = ImageNet100Train if train else ImageNet100Test
+    x, y, t = dataset.get_data()
+
+    assert len(x) == nb_images_per_subset[train]
+
+
+@pytest.mark.parametrize("train,div", [
+    (True, 1), (True, 2),
+    (False, 1), (True, 2)
+])
+def test_customsubset_imagenet100(ImageNet100Train, ImageNet100Test, train, div):
+    dataset = ImageNet100Train if train else ImageNet100Test
+    x, y, t = dataset.get_data()
+
+    new_x = x[:len(x) // div]
+    new_y = y[:len(y) // div]
+
+    subset = ImageNet100(dataset.data_folder, data_subset=(new_x, new_y), download=False, train=train)
+    x2, y2, t2 = subset.get_data()
+
+    assert len(x) // div == len(x2)
+
+
+


### PR DESCRIPTION
Found a bug in ImageNet100, the hot-fix is already deployed but I've made some tests to ensure no more errors happen.

This test only download the text file of ids, so it's quite fast.