### PR TITLE
added choice of object/category level detection

### DIFF
--- a/continuum/datasets/core50.py
+++ b/continuum/datasets/core50.py
@@ -31,13 +31,16 @@ class Core50(_ContinuumDataset):
             train: bool = True,
             train_image_ids: Union[str, Iterable[str], None] = None,
             scenario: str = "classes",
-            download: bool = True
+            download: bool = True,
+            classification: str = "object"
     ):
         assert scenario in ["classes", "domains", "objects"]
+        assert classification in ["object", "category"]
         self.train_image_ids = train_image_ids
         super().__init__(data_path=data_path, train=train, download=download)
 
         self.scenario = scenario
+        self.classification = classification
 
         if self.train_image_ids is None:
             self.train_image_ids = os.path.join(self.data_path, "core50_train.csv")
@@ -126,7 +129,12 @@ class Core50(_ContinuumDataset):
                         continue
 
                     x.append(os.path.join(object_folder, path))
-                    class_label = object_id // 5
+                    if self.classification == "object":
+                        # Ranges from 0-49
+                        class_label = object_id
+                    else:
+                        # Ranges from 0-9
+                        class_label = object_id // 5
                     y.append(class_label)
 
                     if self.train:  # We add a new domain id for the train set.


### PR DESCRIPTION
Hello @arthurdouillard,

The original Core50 dataset actually has two choices of classification goals.

Category level classification is what the Continuum library currently supports. The labels range from 0-9 where cup1 is the same as cup2 in terms of model classification correctness.

However, the benchmark for Core50, as written on the author's website for Core50, is actually for object detection, where the model should be able to distinguish between cup1 and cup2, and is a more difficult task.

This pull request makes it possible to switch between the two modes. 