### PR TITLE
Bug Fix - metrics.py

### DIFF
--- a/continuum/metrics/metrics.py
+++ b/continuum/metrics/metrics.py
@@ -230,7 +230,7 @@ def get_model_size(model):
     """
     nb_params = 0
     # store original state
-    orig_state = model.training()
+    orig_state = model.training
     # we want the number of parameter for inference
     model.eval()
     for w in model.parameters():
@@ -239,7 +239,7 @@ def get_model_size(model):
         else:  # Scalar
             nb_params += 1
     # restore previous state
-    model.training(orig_state)
+    model.train(orig_state)
     return nb_params
 
 

--- a/continuum/metrics/metrics.py
+++ b/continuum/metrics/metrics.py
@@ -229,14 +229,17 @@ def get_model_size(model):
     :return: The number of parameters.
     """
     nb_params = 0
-    # we want he number of parameter for inference
+    # store original state
+    orig_state = model.training()
+    # we want the number of parameter for inference
     model.eval()
     for w in model.parameters():
         if len(w.shape) > 0:  # Tensor
             nb_params += reduce(lambda a, b: a * b, w.shape)
         else:  # Scalar
             nb_params += 1
-
+    # restore previous state
+    model.training(orig_state)
     return nb_params
 
 


### PR DESCRIPTION
Turning on evaluation mode with `model.eval()` in `get_model_size` may cause a lot of errors if the user does not switch it back to the original training state in the calling function.

I've integrated restoring the previous state here.