### PR TITLE
Handle negative indices in a simpler way

### DIFF
--- a/continuum/scenarios/base.py
+++ b/continuum/scenarios/base.py
@@ -190,6 +190,6 @@ class _BaseScenario(abc.ABC):
 
 
 def _handle_negative_indexes(index: int, total_len: int) -> int:
-    while index < 0:
-        index += total_len
+    if index < 0:
+        index = index % total_len
     return index


### PR DESCRIPTION
Maybe change

https://github.com/Continvvm/continuum/blob/a80971f21bcef265192056e775e41633e8161ac2/continuum/scenarios/base.py#L193-L194

to

```python
index = index % total_len
```

will make it simpler and more efficient when `index` is very small?