### PR TITLE
ALMA integration

### DIFF
--- a/continuum/scenarios/__init__.py
+++ b/continuum/scenarios/__init__.py
@@ -4,6 +4,7 @@ from continuum.scenarios.base import _BaseScenario
 from continuum.scenarios.continual_scenario import ContinualScenario
 from continuum.scenarios.class_incremental import ClassIncremental
 from continuum.scenarios.instance_incremental import InstanceIncremental
+from continuum.scenarios.specific_scenarios import ALMA
 from continuum.scenarios.transformation_incremental import TransformationIncremental
 from continuum.scenarios.rotations import Rotations
 from continuum.scenarios.permutations import Permutations
@@ -24,5 +25,6 @@ __all__ = [
     "SegmentationClassIncremental",
     "HashedScenario",
     "OnlineFellowship",
-    "hf"
+    "hf",
+    "ALMA"
 ]

--- a/continuum/scenarios/specific_scenarios.py
+++ b/continuum/scenarios/specific_scenarios.py
@@ -40,7 +40,7 @@ class ALMA(InstanceIncremental):
     def _setup(self, nb_tasks: Optional[int]) -> int:
         x, y, t = self.cl_dataset.get_data()
 
-        if len(y) <= nb_tasks:
+        if len(y) < nb_tasks:
             raise Exception('Cannot have more tasks than available samples in the dataset')
 
         if t is not None:
@@ -48,7 +48,7 @@ class ALMA(InstanceIncremental):
                 f"The chosen dataset provides a task-id for each sample. This is ignored by ALMA."
             )
 
-        if nb_tasks is not None and nb_tasks > 0:  # If the user wants a particular nb of tasks
+        if nb_tasks > 0:
 
             # unlike as in `InstanceIncremental`, we shuffle how samples are assigned to tasks.
             np.random.seed(self.alma_random_seed)
@@ -61,7 +61,6 @@ class ALMA(InstanceIncremental):
 
             self.dataset = (x, y, task_ids)
         else:
-            raise Exception(f"The dataset ({self.cl_dataset}) doesn't provide task ids, "
-                            f"you must then specify a number of tasks, not ({nb_tasks}.")
+            raise Exception(f"You must then specify a positive number of tasks, not {nb_tasks}.")
 
         return nb_tasks

--- a/continuum/scenarios/specific_scenarios.py
+++ b/continuum/scenarios/specific_scenarios.py
@@ -1,0 +1,60 @@
+import warnings
+from typing import Callable, List, Optional, Union
+
+from continuum.datasets import _ContinuumDataset
+from continuum.scenarios import InstanceIncremental
+from continuum.scenarios.instance_incremental import _split_dataset
+
+import numpy as np
+
+class ALMA(InstanceIncremental):
+    """ALMA Loader, generating tasks by randomly partioning a fixed dataset.
+    NOTE: this is analogous to InstanceIncremental, but reformatted with the
+    language of the paper https://arxiv.org/abs/2106.09563
+
+    Scenario: Classes are always the same but instances change (NI scenario)
+
+    :param cl_dataset: A continual dataset.
+    :param nb_megabatches: The scenario number of megabatches (chunks, partitions)
+    :param transformations: A list of transformations applied to all tasks. If
+                            it's a list of list, then the transformation will be
+                            different per task.
+    :param random_seed: A random seed to init random processes.
+    """
+    def __init__(
+            self,
+            cl_dataset: _ContinuumDataset,
+            nb_megabatches: Optional[int] = None,
+            transformations: Union[List[Callable], List[List[Callable]]] = None,
+            random_seed: int = 1
+    ):
+
+        if nb_megabatches is None:
+            raise Exception('User must specify the number of mega-batches in the stream')
+
+        self.alma_random_seed = random_seed
+        super().__init__(cl_dataset=cl_dataset, nb_tasks=nb_megabatches, \
+                transformations=transformations, random_seed=random_seed)
+
+    def _setup(self, nb_tasks: Optional[int]) -> int:
+        x, y, t = self.cl_dataset.get_data()
+
+        if t is not None:
+            warnings.warn(
+                f"The chosen dataset provides a task-id for each sample. This is ignored by ALMA."
+            )
+
+        if nb_tasks is not None and nb_tasks > 0:  # If the user wants a particular nb of tasks
+            task_ids = _split_dataset(y, nb_tasks)
+
+            # unlike as in `InstanceIncremental`, we shuffle how samples are assigned to tasks.
+            np.random.seed(self.alma_random_seed)
+            permutation = np.random.permutation(np.arange(task_ids.shape[0]))
+            task_ids = task_ids[permutation]
+
+            self.dataset = (x, y, task_ids)
+        else:
+            raise Exception(f"The dataset ({self.cl_dataset}) doesn't provide task ids, "
+                            f"you must then specify a number of tasks, not ({nb_tasks}.")
+
+        return nb_tasks

--- a/docs/tutorials/scenarios_suites/ALMA.rst
+++ b/docs/tutorials/scenarios_suites/ALMA.rst
@@ -1,0 +1,46 @@
+ALMA
+-----------------
+
+ALMA (On Anytime Learning At Macroscale) is a new framework, where like (offline) Continual Learning, data arrive sequentially in large (mega)batches over time (see [paper](https://arxiv.org/abs/2106.09563).
+Unlike CL however, we do not assume that there is a shift in the underlying distribution. Rather, the goal of ALMA is develop strategies that perform well troughout the learning experience (not just at the end), and that do so efficiently from a compute and memory perspective. ALMA explore a different line of questions arising in this setting, namely : 
+
+1. How long should a model wait and aggregate data before training again ?
+2. Should the model increase its capacity over time to account for the additional data ?
+ 
+
+Continuum Scenarios
+##########
+
+ALMA is a different framing of `InstanceIncremental` therefore we focus on this scenario.
+
+
+- Instance Incremental
+""""""""
+-- Environment incremental Scenario --
+
+.. code-block:: python
+
+    dataset = Core50("/your/path", scenario="domains", classification="category", train=True)
+    # 8 tasks in 1 environment each with 10 classes
+    scenario = ContinualScenario(dataset, nb_tasks=5)
+
+-- Object incremental Scenario --
+.. code-block:: python
+
+    from continuum.datasets import COre50
+    dataset = Core50("/your/path", scenario="objects", classification="object", train=True)
+    # 50 tasks with 1 object videos in the 8 training environments
+    # classes are object ids (50 classes then)
+    scenario = ContinualScenario(dataset)
+
+
+- Classes and Instances Incremental
+""""""""
+
+Class and Instances Incremental scenarios are proposed in the scenario from the original paper (next section).
+
+.. code-block:: python
+
+    from continuum.scenarios import ALMA
+    scenario = ALMA(your_dataset, nb_megabatches=50)
+

--- a/tests/test_specific_scenarios.py
+++ b/tests/test_specific_scenarios.py
@@ -82,15 +82,10 @@ def test_instance_default_nb_tasks(numpy_data_per_task, nb_tasks, nb_tasks_gt):
             assert len(unique_pixels) == 1 and unique_pixels[0] == float(task_id)
 
 
-@pytest.mark.parametrize("nb_tasks,error", [(301, "error"), (300, None), (300, "warning")])
+@pytest.mark.parametrize("nb_tasks,error", [(2000, "error"), (300, None)])
 def test_too_many_tasks(numpy_data_per_task, nb_tasks, error):
     train, test = numpy_data_per_task
     x_train, y_train, t_train = train
-
-    if error == "warning":
-        x_train = x_train[:-50]
-        y_train = y_train[:-50]
-        t_train = t_train[:-50]
 
     dummy = InMemoryDataset(x_train, y_train, t=t_train)
 
@@ -168,6 +163,7 @@ def test_instance_data_split_not_equally(unequal_data):
     (2, 2),
     (6, 6),
 ])
+
 def test_data_is_shuffled(numpy_data_per_task, nb_tasks, nb_tasks_gt):
     """Make sure the data is shuffled before splitting into tasks"""
     train, test = numpy_data_per_task
@@ -187,5 +183,6 @@ def test_data_is_shuffled(numpy_data_per_task, nb_tasks, nb_tasks_gt):
         task_x = train_dataset._x
         unshuffled_task_x = x_train[task_id*items_per_task:(task_id+1)*items_per_task]
 
+        assert task_x.shape == unshuffled_task_x.shape
         assert not np.allclose(task_x, unshuffled_task_x)
 

--- a/tests/test_specific_scenarios.py
+++ b/tests/test_specific_scenarios.py
@@ -137,28 +137,6 @@ def unequal_data():
     return x, y
 
 
-def test_instance_data_split_not_equally(unequal_data):
-    x, y = unequal_data
-    dataset = InMemoryDataset(x, y)
-    scenario = ALMA(dataset, nb_megabatches=5)
-
-    c_0, c_1, c_2, c_3 = 0, 0, 0, 0
-
-    for taskset in scenario:
-        bincount = np.bincount(taskset._y, minlength=4)
-        c_0 += bincount[0]
-        c_1 += bincount[1]
-        c_2 += bincount[2]
-        c_3 += bincount[3]
-
-    bincount = np.bincount(y)
-    assert c_0 == bincount[0]
-    assert c_1 == bincount[1]
-    assert c_2 == bincount[2]
-    assert c_3 == bincount[3]
-    assert c_0 + c_1 + c_2 + c_3 == len(x)
-
-
 @pytest.mark.parametrize("nb_tasks,nb_tasks_gt", [
     (2, 2),
     (6, 6),

--- a/tests/test_specific_scenarios.py
+++ b/tests/test_specific_scenarios.py
@@ -1,0 +1,191 @@
+import numpy as np
+import pytest
+
+from continuum.datasets import InMemoryDataset
+from continuum.scenarios import ALMA
+
+# yapf: disable
+
+
+@pytest.fixture
+def numpy_data():
+    nb_classes = 6
+    nb_data = 100
+
+    x_train = []
+    y_train = []
+    for i in range(nb_classes):
+        x_train.append(np.ones((nb_data, 4, 4, 3), dtype=np.uint8) * i)
+        y_train.append(np.ones(nb_data) * i)
+    x_train = np.concatenate(x_train)
+    y_train = np.concatenate(y_train)
+
+    x_test = np.copy(x_train)
+    y_test = np.copy(y_train)
+
+    return (x_train, y_train.astype(int)), (x_test, y_test.astype(int))
+
+
+@pytest.mark.parametrize("nb_tasks,nb_tasks_gt", [
+    (2, 2),
+    (6, 6),
+    (1, 1),
+])
+
+
+@pytest.fixture
+def numpy_data_per_task():
+    nb_classes = 6
+    nb_tasks = 3
+    nb_data = 100
+
+    x_train = []
+    y_train = []
+    t_train = []
+    for i in range(nb_tasks):
+        for j in range(nb_classes):
+            x_train.append(np.ones((nb_data, 4, 4, 3), dtype=np.uint8) * i)
+            y_train.append(np.ones(nb_data) * j)
+            t_train.append(np.ones(nb_data) * i)
+    x_train = np.concatenate(x_train)
+    y_train = np.concatenate(y_train)
+    t_train = np.concatenate(t_train)
+
+    x_test = np.copy(x_train)
+    y_test = np.copy(y_train)
+    t_test = np.copy(t_train)
+
+    return (x_train, y_train.astype(int), t_train), (x_test, y_test.astype(int), t_test)
+
+@pytest.mark.parametrize("nb_tasks,nb_tasks_gt", [
+    (2, 2),
+    (6, 6),
+])
+def test_instance_default_nb_tasks(numpy_data_per_task, nb_tasks, nb_tasks_gt):
+    """Test the ALMA loader when the dataset does provide
+    a default number of tasks."""
+    train, test = numpy_data_per_task
+
+    x_train, y_train, t_train = train
+
+    dummy = InMemoryDataset(x_train, y_train, t=t_train)
+
+    scenario = ALMA(dummy, nb_megabatches=nb_tasks)
+    nb_classes = scenario.nb_classes
+
+    assert len(scenario) == nb_tasks_gt, (nb_tasks, nb_tasks_gt)
+    for task_id, train_dataset in enumerate(scenario):
+        assert nb_classes == len(np.unique(train_dataset._y))
+
+        unique_pixels = np.unique(train_dataset._x)
+        if nb_tasks is None:
+            assert len(unique_pixels) == 1 and unique_pixels[0] == float(task_id)
+
+
+@pytest.mark.parametrize("nb_tasks,error", [(301, "error"), (300, None), (300, "warning")])
+def test_too_many_tasks(numpy_data_per_task, nb_tasks, error):
+    train, test = numpy_data_per_task
+    x_train, y_train, t_train = train
+
+    if error == "warning":
+        x_train = x_train[:-50]
+        y_train = y_train[:-50]
+        t_train = t_train[:-50]
+
+    dummy = InMemoryDataset(x_train, y_train, t=t_train)
+
+    if error == "error":
+        with pytest.raises(Exception):
+            scenario = ALMA(dummy, nb_megabatches=nb_tasks)
+    elif error == "warning":
+        with pytest.warns(Warning):
+            scenario = ALMA(dummy, nb_megabatches=nb_tasks)
+    else:
+        scenario = ALMA(dummy, nb_megabatches=nb_tasks)
+
+
+
+@pytest.mark.parametrize("nb_tasks", [None, 0, -1])
+def test_invalid(numpy_data_per_task, nb_tasks):
+    train, test = numpy_data_per_task
+
+    x_train, y_train, t_train = train
+    x_test, y_test, t_test = test
+
+    dummy = InMemoryDataset(x_train, y_train)
+
+    with pytest.raises(Exception):
+        ALMA(dummy, nb_megabatches=nb_tasks)
+
+
+@pytest.fixture
+def equal_data():
+    x = np.ones((100, 4, 4, 3), dtype=np.uint8)
+    y = np.concatenate((
+        np.ones((25,), dtype=np.uint32) * 0,
+        np.ones((50,), dtype=np.uint32) * 1,
+        np.ones((10,), dtype=np.uint32) * 2,
+        np.ones((15,), dtype=np.uint32) * 3,
+    ))
+    return x, y
+
+
+@pytest.fixture
+def unequal_data():
+    y = np.concatenate((
+        np.ones((22,), dtype=np.uint32) * 0,
+        np.ones((53,), dtype=np.uint32) * 1,
+        np.ones((19,), dtype=np.uint32) * 2,
+        np.ones((7,), dtype=np.uint32) * 3,
+    ))
+    x = np.ones((len(y), 4, 4, 3), dtype=np.uint8)
+    return x, y
+
+
+def test_instance_data_split_not_equally(unequal_data):
+    x, y = unequal_data
+    dataset = InMemoryDataset(x, y)
+    scenario = ALMA(dataset, nb_megabatches=5)
+
+    c_0, c_1, c_2, c_3 = 0, 0, 0, 0
+
+    for taskset in scenario:
+        bincount = np.bincount(taskset._y, minlength=4)
+        c_0 += bincount[0]
+        c_1 += bincount[1]
+        c_2 += bincount[2]
+        c_3 += bincount[3]
+
+    bincount = np.bincount(y)
+    assert c_0 == bincount[0]
+    assert c_1 == bincount[1]
+    assert c_2 == bincount[2]
+    assert c_3 == bincount[3]
+    assert c_0 + c_1 + c_2 + c_3 == len(x)
+
+
+@pytest.mark.parametrize("nb_tasks,nb_tasks_gt", [
+    (2, 2),
+    (6, 6),
+])
+def test_data_is_shuffled(numpy_data_per_task, nb_tasks, nb_tasks_gt):
+    """Make sure the data is shuffled before splitting into tasks"""
+    train, test = numpy_data_per_task
+
+    x_train, y_train, t_train = train
+    items_per_task = x_train.shape[0] // nb_tasks
+
+    dummy = InMemoryDataset(x_train, y_train, t=t_train)
+
+    scenario = ALMA(dummy, nb_megabatches=nb_tasks)
+    nb_classes = scenario.nb_classes
+
+    assert len(scenario) == nb_tasks_gt, (nb_tasks, nb_tasks_gt)
+    for task_id, train_dataset in enumerate(scenario):
+        assert nb_classes == len(np.unique(train_dataset._y))
+
+        task_x = train_dataset._x
+        unshuffled_task_x = x_train[task_id*items_per_task:(task_id+1)*items_per_task]
+
+        assert not np.allclose(task_x, unshuffled_task_x)
+


### PR DESCRIPTION
Added ALMA scenario which Inherits from `InstanceIncremental`

The differences from ALMA to `InstanceIncremental` are : 

1. In ALMA `nb_tasks` is renamed to `nb_megabatches`. 
2. The argument *must* be provided (throws an error otherwise)
3. When splitting the original dataset, we do not enforce that class instances are equally split among tasks. Rather, while each task has the same amount of datapoints (if evenly divisible) each instance is randomly assigned to a task. 
4. Tests have been adapted from `InstanceIncremental`'s tests to account for the points above. 