### PR TITLE
Move package `prospector` to dev dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ scikit-learn>=0.24.1
 pandas>=1.1.5
 pytest>=5.0.1
 pytest-mock>=3.6.1
-prospector[with_mypy]>=1.2.0
 h5py>=3.1.0
 requests>=2.24.0
 ImageHash>=4.2.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,1 @@
+prospector[with_mypy]>=1.2.0


### PR DESCRIPTION
Hello, `prospector` should probably be moved to `requirements_dev.txt` as it is not called from any Python code. This will make it easier to package continuum in Spack. Thanks.